### PR TITLE
Tag image with `latest` and version tag

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -3,11 +3,12 @@ steps:
     entrypoint: 'bash'
     args: [
         '-c',
-        'DOCKER_BUILDKIT=1 docker build -t gcr.io/$PROJECT_ID/$REPO_NAME:$TAG_NAME --build-arg TOKEN=$$TOKEN . --file=./Dockerfile' ]
+        'DOCKER_BUILDKIT=1 docker build -t gcr.io/$PROJECT_ID/$REPO_NAME:latest -t gcr.io/$PROJECT_ID/$REPO_NAME:$TAG_NAME --build-arg TOKEN=$$TOKEN . --file=./Dockerfile' ]
     secretEnv:
       - 'TOKEN'
 images:
   - 'gcr.io/$PROJECT_ID/$REPO_NAME:$TAG_NAME'
+  - 'gcr.io/$PROJECT_ID/$REPO_NAME:latest'
 timeout: 6000s
 options:
   env:


### PR DESCRIPTION
This should allow us to use `:latest` in springbox for all Go services running `go v1.21` and above for which the [Go toolchain](https://go.dev/doc/toolchain) will automatically download the appropriate compiler version.

This way we do not need to update the air image version of services in springbox, it will instead use the local `springbox/src/<service>/go.mod` automatically.