### PR TITLE
Revert "Tag image with `latest` and version tag"

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -3,12 +3,11 @@ steps:
     entrypoint: 'bash'
     args: [
         '-c',
-        'DOCKER_BUILDKIT=1 docker build -t gcr.io/$PROJECT_ID/$REPO_NAME:latest -t gcr.io/$PROJECT_ID/$REPO_NAME:$TAG_NAME --build-arg TOKEN=$$TOKEN . --file=./Dockerfile' ]
+        'DOCKER_BUILDKIT=1 docker build -t gcr.io/$PROJECT_ID/$REPO_NAME:$TAG_NAME --build-arg TOKEN=$$TOKEN . --file=./Dockerfile' ]
     secretEnv:
       - 'TOKEN'
 images:
   - 'gcr.io/$PROJECT_ID/$REPO_NAME:$TAG_NAME'
-  - 'gcr.io/$PROJECT_ID/$REPO_NAME:latest'
 timeout: 6000s
 options:
   env:


### PR DESCRIPTION
Reverts searchspring/air#9

I realize I need to make this change in https://github.com/searchspring/air-base-image, not here. I imagine this one should still be explicitly versioned only?